### PR TITLE
bug: Fix issue with command data mapping

### DIFF
--- a/command/ticket/src/main/java/io/datcord/command/ticket/TicketBoardEntitySelectInteractionEventListener.java
+++ b/command/ticket/src/main/java/io/datcord/command/ticket/TicketBoardEntitySelectInteractionEventListener.java
@@ -8,6 +8,13 @@ import net.dv8tion.jda.api.events.interaction.component.EntitySelectInteractionE
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * This class is responsible for handling entity selection interaction events within the ticket board.
+ * The class implements both the EventModuleInitializer and EntitySelectInteractionEventListener interfaces.
+ * It essentially logs when an entity selection interaction event happens, receives the message from the event,
+ * and then modifies the original embeds of the hook from the event with a new EmbedBuilder instance.
+ * The new embed built by the EmbedBuilder has a title of "Ticket Board Builder" and asks, "What should the board say?".
+ */
 public class TicketBoardEntitySelectInteractionEventListener implements EventModuleInitializer, EntitySelectInteractionEventListener {
 
 

--- a/events/src/main/java/io/datcord/event/session/ReadyEventListener.java
+++ b/events/src/main/java/io/datcord/event/session/ReadyEventListener.java
@@ -47,8 +47,8 @@ public class ReadyEventListener extends ListenerAdapter {
          */
         jda.getGuilds().forEach(guild -> {
             logger.debug("Loading commands for guild {}", guild.getName());
-            readCommands(guild.getIdLong());
             guild.updateCommands().addCommands(readCommands(guild.getIdLong())).queue();
+            logger.debug("Loaded commands for guild {}", guild.getIdLong());
             logger.debug("Loaded features for guild {}", guild.getName());
             //TODO: Add feature loading
         });

--- a/events/src/main/java/io/datcord/mapper/json/impl/SlashCommandJsonMapper.java
+++ b/events/src/main/java/io/datcord/mapper/json/impl/SlashCommandJsonMapper.java
@@ -1,6 +1,8 @@
 package io.datcord.mapper.json.impl;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import io.datcord.mapper.json.JsonMapper;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
@@ -10,6 +12,8 @@ import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.stream.IntStream;
 
 /**
  * This is {@code SlashCommandJsonMapper} class, which extends the {@code JsonMapper<CommandData>} abstract class.
@@ -29,8 +33,19 @@ public class SlashCommandJsonMapper extends JsonMapper<CommandData> {
 
     private static final Logger logger = LoggerFactory.getLogger(SlashCommandJsonMapper.class);
 
+
     @Override
-    protected CommandData parseObject(JsonNode commandNode)  {
+    protected CommandData parseObject(JsonNode node)  {
+        JsonNode commandJsonNode = node.get("commandJson");
+        JsonNode commandNode = null;
+        try {
+            commandNode = mapper.readTree(commandJsonNode.asText());
+        } catch (JsonProcessingException e) {
+            logger.error("Failed to parse command json", e);
+            throw new RuntimeException(e);
+        }
+        logger.debug("Parsing command data {}", commandNode.toString());
+        logger.debug("Command name {}", commandNode.get("name"));
         String name = commandNode.get("name").asText();
         String description = commandNode.get("description").asText();
 
@@ -91,4 +106,5 @@ public class SlashCommandJsonMapper extends JsonMapper<CommandData> {
         return slashCommandData;
     }
 
+    private final ObjectMapper mapper = new ObjectMapper();
 }


### PR DESCRIPTION
When the response containing command data was mapped it was wrapped in a "commandJson" object and the properties of that were not being accessed correctly. This change unwraps the command data from the "commandJson" object. Just reading the node within in "commandJson" would return a String type node which is then mapped to a root node so the properties can be accessed.